### PR TITLE
 vayu: libinit: Don't spoof green state in init

### DIFF
--- a/libinit/init_vayu.cpp
+++ b/libinit/init_vayu.cpp
@@ -117,9 +117,7 @@ void vendor_load_properties() {
     }
 
     load_dalvik_properties();
-
-//  SafetyNet workaround
-    property_override("ro.boot.verifiedbootstate", "green");
+   
 //  Enable transitional log for Privileged permissions
     property_override("ro.control_privapp_permissions", "log");
 }


### PR DESCRIPTION
It will broke the recovery unlocked state, PixelExpiernce will Spoof this green state by system init in PE source alrady